### PR TITLE
Add directory_name argument to specification_list tag.

### DIFF
--- a/schemas/document/ru/uslugi/definitions/person_fio.json
+++ b/schemas/document/ru/uslugi/definitions/person_fio.json
@@ -1,7 +1,7 @@
 {
   "id": "http://edoc-schema.kzn.ru/document/ru/uslugi/definitions/person_fio",
   "$schema": "http://json-schema.org/draft-06/schema#",
-  "description": "ФИО и мобильный телефон",
+  "description": "ФИО человека",
   "type": "object",
   "properties": {
     "raw": {"type": "string", "title": "фио"},

--- a/specification.md
+++ b/specification.md
@@ -8,7 +8,29 @@ permalink: /specification/
 Стандартные схемы данных
 ------------------------
 
-{% specification_list %}
+### Classifier
+{% specification_list directory_name:classifier %}
+
+### Document
+{% specification_list directory_name:document %}
+
+### Generic
+{% specification_list directory_name:generic %}
+
+### Geo
+{% specification_list directory_name:geo %}
+
+### Identifier
+{% specification_list directory_name:identifier %}
+
+### Location
+{% specification_list directory_name:location %}
+
+### Organization
+{% specification_list directory_name:organization %}
+
+### Person
+{% specification_list directory_name:person %}
 
 Стандартный контейнер документа
 -------------------------------


### PR DESCRIPTION
Just use  {% specification_list %} to render specifications from all schema folders.
